### PR TITLE
Implement spiral pattern terrain generation

### DIFF
--- a/src/game/world/ChunkManager.ts
+++ b/src/game/world/ChunkManager.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import { Chunk } from './Chunk'
 import { ChunkStorage } from './ChunkStorage'
+import { SpiralHelper2d } from './SpiralHelper2d'
 import { TerrainGenerator } from './TerrainGenerator'
 
 export class ChunkManager {
@@ -19,32 +20,16 @@ export class ChunkManager {
 
     const newChunks: Chunk[] = []
 
-    const chunkPosition = new THREE.Vector3(0, 0, 0)
-    const chunkDimensions = new THREE.Vector3(
-      this.chunks.chunkDimensions.x,
-      this.chunks.chunkDimensions.y,
-      this.chunks.chunkDimensions.z
-    )
+    const spiral = new SpiralHelper2d(this.renderDistanceX)
+    const positions = spiral.generateSpiral()
 
-    for (let cx = x - this.renderDistance.x; cx <= x + this.renderDistance.x; cx++) {
-      for (let cy = y - this.renderDistance.y; cy <= y + this.renderDistance.y; cy++) {
-        for (let cz = z - this.renderDistance.z; cz <= z + this.renderDistance.z; cz++) {
-          chunkPosition.set(cx, cy, cz)
-
-          const chunk = this.chunks.getChunk(chunkPosition)
-          if (chunk) continue
-
-          const newChunk = new Chunk(
-            this.terrainGenerator,
-            chunkPosition.clone(),
-            chunkDimensions
-          )
-
-          this.chunks.addChunk(newChunk)
-          newChunks.push(newChunk)
-        }
+    positions.forEach(position => {
+      for (let columnY = y - this.renderDistanceY; columnY <= y + this.renderDistanceY; columnY++) {
+        const chunk = new Chunk(this.terrainGenerator, position.x + x, columnY, position.y + z)
+        this.chunks.addChunk(chunk)
+        newChunks.push(chunk)
       }
-    }
+    })
 
     return newChunks
   }

--- a/src/game/world/ChunkManager.ts
+++ b/src/game/world/ChunkManager.ts
@@ -20,12 +20,15 @@ export class ChunkManager {
 
     const newChunks: Chunk[] = []
 
-    const spiral = new SpiralHelper2d(this.renderDistanceX)
+    const spiralRadius = Math.min(this.renderDistance.x, this.renderDistance.z)
+
+    const spiral = new SpiralHelper2d(spiralRadius)
     const positions = spiral.generateSpiral()
 
     positions.forEach(position => {
-      for (let columnY = y - this.renderDistanceY; columnY <= y + this.renderDistanceY; columnY++) {
-        const chunk = new Chunk(this.terrainGenerator, position.x + x, columnY, position.y + z)
+      for (let columnY = y - this.renderDistance.y; columnY <= y + this.renderDistance.y; columnY++) {
+        const chunkPosition = new THREE.Vector3(position.x + x, columnY, position.y + z)
+        const chunk = new Chunk(this.terrainGenerator, chunkPosition, this.chunks.chunkDimensions)
         this.chunks.addChunk(chunk)
         newChunks.push(chunk)
       }

--- a/src/game/world/SpiralHelper2d.test.ts
+++ b/src/game/world/SpiralHelper2d.test.ts
@@ -58,4 +58,21 @@ describe('#generateSpiral()', () => {
       { x: 2, y: 2 },
     ])
   })
+
+  test('should generate correct positions for a different origin', () => {
+    const helper = new SpiralHelper2d(1, { x: 3, y: 5 })
+    const positions = helper.generateSpiral()
+
+    expect(positions).toEqual([
+      { x: 3, y: 5 },
+      { x: 4, y: 5 },
+      { x: 4, y: 4 },
+      { x: 3, y: 4 },
+      { x: 2, y: 4 },
+      { x: 2, y: 5 },
+      { x: 2, y: 6 },
+      { x: 3, y: 6 },
+      { x: 4, y: 6 },
+    ])
+  })
 })

--- a/src/game/world/SpiralHelper2d.test.ts
+++ b/src/game/world/SpiralHelper2d.test.ts
@@ -2,10 +2,26 @@ import { expect, test, describe } from "vitest";
 import { SpiralHelper2d } from "./SpiralHelper2d";
 
 describe('#generateSpiral()', () => {
-  const helper = new SpiralHelper2d(1)
-  const positions = helper.generateSpiral()
+  test('should generate correct amount of positions', () => {
+    for (let radius = 0; radius < 10; radius++) {
+      const helper = new SpiralHelper2d(radius)
+      const positions = helper.generateSpiral()
 
-  test('should generate correct positions', () => {
+      const sideLength = radius * 2 + 1
+      expect(positions.length).toEqual(sideLength * sideLength)
+    }
+  })
+
+  test('should return origin when radius < 1', () => {
+    const helper = new SpiralHelper2d(0)
+    const positions = helper.generateSpiral()
+    expect(positions).toEqual([{ x: 0, y: 0 }])
+  })
+
+  test('should generate correct positions for a small spiral', () => {
+    const helper = new SpiralHelper2d(1)
+    const positions = helper.generateSpiral()
+
     expect(positions).toEqual([
       { x: 0, y: 0 },
       { x: 1, y: 0 },
@@ -16,6 +32,30 @@ describe('#generateSpiral()', () => {
       { x: -1, y: 1 },
       { x: 0, y: 1 },
       { x: 1, y: 1 },
+    ])
+  })
+
+  test('should generate correct positions for bigger spirals', () => {
+    const helper = new SpiralHelper2d(2)
+    const positions = helper.generateSpiral()
+
+    expect(positions.slice(9)).toEqual([
+      { x: 2, y: 1 },
+      { x: 2, y: 0 },
+      { x: 2, y: -1 },
+      { x: 2, y: -2 },
+      { x: 1, y: -2 },
+      { x: 0, y: -2 },
+      { x: -1, y: -2 },
+      { x: -2, y: -2 },
+      { x: -2, y: -1 },
+      { x: -2, y: 0 },
+      { x: -2, y: 1 },
+      { x: -2, y: 2 },
+      { x: -1, y: 2 },
+      { x: 0, y: 2 },
+      { x: 1, y: 2 },
+      { x: 2, y: 2 },
     ])
   })
 })

--- a/src/game/world/SpiralHelper2d.test.ts
+++ b/src/game/world/SpiralHelper2d.test.ts
@@ -1,0 +1,21 @@
+import { expect, test, describe } from "vitest";
+import { SpiralHelper2d } from "./SpiralHelper2d";
+
+describe('#generateSpiral()', () => {
+  const helper = new SpiralHelper2d(1)
+  const positions = helper.generateSpiral()
+
+  test('should generate correct positions', () => {
+    expect(positions).toEqual([
+      { x: 0, y: 0 },
+      { x: 1, y: 0 },
+      { x: 1, y: -1 },
+      { x: 0, y: -1 },
+      { x: -1, y: -1 },
+      { x: -1, y: 0 },
+      { x: -1, y: 1 },
+      { x: 0, y: 1 },
+      { x: 1, y: 1 },
+    ])
+  })
+})

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -28,14 +28,15 @@ export class SpiralHelper2d {
 
     let { x, y } = this.origin
 
-    while (this.radius < this.maxRadius || this.directionIndex % 4 !== 1) {
+    while (this.radius < this.maxRadius || this.directionIndex === 0) {
       for (let i = 0; i < this.stepSize; i++) {
         this.positions.push({ x, y })
-        x += SpiralHelper2d.directions[this.directionIndex % 4].x
-        y += SpiralHelper2d.directions[this.directionIndex % 4].y
+        x += SpiralHelper2d.directions[this.directionIndex].x
+        y += SpiralHelper2d.directions[this.directionIndex].y
       }
 
       this.directionIndex++
+      this.directionIndex %= 4
 
       if (this.directionIndex % 2 === 0) this.stepSize++
       if (this.directionIndex % 4 === 0) this.radius++

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -1,21 +1,29 @@
+export type Point2d = { x: number; y: number }
+
 export class SpiralHelper2d {
-  constructor(public radius: number) { }
+  public directionIndex: number
+  public positions: Point2d[]
+
+  public static directions = [
+    { x: 1, y: 0 },
+    { x: 0, y: 1 },
+    { x: -1, y: 0 },
+    { x: 0, y: -1 }
+  ]
+
+  constructor(
+    public radius: number,
+    public origin: Point2d = { x: 0, y: 0 }
+  ) {
+    this.directionIndex = 0
+    this.positions = []
+  }
 
   generateSpiral() {
-    let x = 0
-    let y = 0
+    let { x, y } = this.origin
 
-    const directions = [
-      { x: 1, y: 0 },
-      { x: 0, y: 1 },
-      { x: -1, y: 0 },
-      { x: 0, y: -1 }
-    ]
+    // TODO: implement
 
-    const positions = []
-
-    // TODO: Implement
-
-    return positions
+    return this.positions
   }
 }

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -3,26 +3,46 @@ export type Point2d = { x: number; y: number }
 export class SpiralHelper2d {
   public directionIndex: number
   public positions: Point2d[]
+  public radius: number
 
   public static directions = [
     { x: 1, y: 0 },
-    { x: 0, y: 1 },
+    { x: 0, y: -1 },
     { x: -1, y: 0 },
-    { x: 0, y: -1 }
+    { x: 0, y: 1 }
   ]
 
   constructor(
-    public radius: number,
+    public maxRadius: number,
     public origin: Point2d = { x: 0, y: 0 }
   ) {
     this.directionIndex = 0
     this.positions = []
+    this.radius = 0
   }
 
   generateSpiral() {
     let { x, y } = this.origin
+    let stepSize = 1
 
-    // TODO: implement
+    while (this.radius < this.maxRadius) {
+      console.log({ stepSize, x, y, i: this.directionIndex, m5: this.directionIndex % 5 })
+      for (let i = 0; i < stepSize; i++) {
+        this.positions.push({ x, y })
+        x += SpiralHelper2d.directions[this.directionIndex % 4].x
+        y += SpiralHelper2d.directions[this.directionIndex % 4].y
+      }
+
+      this.directionIndex++
+
+      if (this.directionIndex % 5 === 0) {
+        this.radius++
+      }
+
+      if (this.directionIndex % 2 === 0) {
+        stepSize++
+      }
+    }
 
     return this.positions
   }

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -1,0 +1,21 @@
+export class SpiralHelper2d {
+  constructor(public radius: number) { }
+
+  generateSpiral() {
+    let x = 0
+    let y = 0
+
+    const directions = [
+      { x: 1, y: 0 },
+      { x: 0, y: 1 },
+      { x: -1, y: 0 },
+      { x: 0, y: -1 }
+    ]
+
+    const positions = []
+
+    // TODO: Implement
+
+    return positions
+  }
+}

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -4,6 +4,7 @@ export class SpiralHelper2d {
   public directionIndex: number
   public positions: Point2d[]
   public radius: number
+  public stepSize: number
 
   public static directions = [
     { x: 1, y: 0 },
@@ -19,15 +20,14 @@ export class SpiralHelper2d {
     this.directionIndex = 0
     this.positions = []
     this.radius = 0
+    this.stepSize = 1
   }
 
   generateSpiral() {
     let { x, y } = this.origin
-    let stepSize = 1
 
     while (this.radius < this.maxRadius) {
-      console.log({ stepSize, x, y, i: this.directionIndex, m5: this.directionIndex % 5 })
-      for (let i = 0; i < stepSize; i++) {
+      for (let i = 0; i < this.stepSize; i++) {
         this.positions.push({ x, y })
         x += SpiralHelper2d.directions[this.directionIndex % 4].x
         y += SpiralHelper2d.directions[this.directionIndex % 4].y
@@ -35,13 +35,8 @@ export class SpiralHelper2d {
 
       this.directionIndex++
 
-      if (this.directionIndex % 5 === 0) {
-        this.radius++
-      }
-
-      if (this.directionIndex % 2 === 0) {
-        stepSize++
-      }
+      if (this.directionIndex % 2 === 0) this.stepSize++
+      if (this.directionIndex % 5 === 0) this.radius++
     }
 
     return this.positions

--- a/src/game/world/SpiralHelper2d.ts
+++ b/src/game/world/SpiralHelper2d.ts
@@ -24,9 +24,11 @@ export class SpiralHelper2d {
   }
 
   generateSpiral() {
+    if (this.maxRadius < 1) return [this.origin]
+
     let { x, y } = this.origin
 
-    while (this.radius < this.maxRadius) {
+    while (this.radius < this.maxRadius || this.directionIndex % 4 !== 1) {
       for (let i = 0; i < this.stepSize; i++) {
         this.positions.push({ x, y })
         x += SpiralHelper2d.directions[this.directionIndex % 4].x
@@ -36,7 +38,7 @@ export class SpiralHelper2d {
       this.directionIndex++
 
       if (this.directionIndex % 2 === 0) this.stepSize++
-      if (this.directionIndex % 5 === 0) this.radius++
+      if (this.directionIndex % 4 === 0) this.radius++
     }
 
     return this.positions


### PR DESCRIPTION
Replaced line by line chunk generation with a spiral pattern.

Basic illustration / pattern recognition:
- The spiral spins clockwise
- Cells represent chunk columns
- Cell value represents its index
- +x,-x,+y,-y,+z,-z represent the direction in which the origin will translate in the next step
- Discard assumes that by the end of the step loop, the position is overstepped by one value and thus should be popped / discarded from the positions array

![CleanShot 2024-01-30 at 08 14 02@2x](https://github.com/CuddlyBunion341/tsmc2/assets/53896675/40999f3e-900d-4def-b1d0-27c96f7e201c)

## Benefits
- The player can be spawned into the world much faster
- Less relevant terrain gets generated later
- It is less booring

## Todo
- [ ] RenderDistanceZ is ignored (maybe replace with horizontalRenderDistance?)
- [ ] Class name SpiralHelper is awkward
- [ ] Remove spiral origin?

https://github.com/CuddlyBunion341/tsmc2/assets/53896675/7b181625-59ff-4169-987a-d8f4a6b81d96


<details>
<summary>Before the change</summary>

https://github.com/CuddlyBunion341/tsmc2/assets/53896675/4f9aea0d-2165-433d-ba95-72d0a76a1202

</details>

