### PR TITLE
Implement ambient occlusion

### DIFF
--- a/src/game/world/Chunk.ts
+++ b/src/game/world/Chunk.ts
@@ -44,7 +44,7 @@ export class Chunk {
     this.chunkMesher = new ChunkMesher(dimensions, this.chunkData)
     this.mesh = new THREE.Mesh()
     this.mesh.position.add(this.position.clone().multiply(this.dimensions))
-    this.mesh.material = new THREE.MeshMatcapMaterial({vertexColors: true})
+    this.mesh.material = new THREE.MeshBasicMaterial({vertexColors: true})
   }
 
   generateTerrain() {

--- a/src/game/world/ChunkMesher.ts
+++ b/src/game/world/ChunkMesher.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three'
-import { blocks } from './blocks'
+import { blockIds, blocks } from './blocks'
 import { ChunkData } from './ChunkData'
 
 export type Vertex = {
@@ -140,6 +140,8 @@ export class ChunkMesher {
 
     const color = blocks[blockId].color
 
+    const vertexPosition = new THREE.Vector3(0,0,0)
+
     const faceVertices = ChunkMesher.vertexData
       .slice(firstFaceVertexIndex, firstFaceVertexIndex + FACE_VERTEX_COUNT)
       .map((vertex) => {
@@ -149,12 +151,50 @@ export class ChunkMesher {
           vertex.position[2] / 2 + blockPosition.z
         ]
 
+        const ao = this.calculateVertexAO(vertexPosition.set(...position))
+
         // TODO: calculate light level
-        // TODO: calculate AO
         // TODO: calculate UVs
-        return { ...vertex, position, color }
+        return { ...vertex, position, color: color.map(v => v * ao) as [number,number,number] }
       })
 
     return faceVertices
+  }
+
+  affectsAo(blockId: number) {
+    return blockId !== blockIds.air
+  }
+
+  positionAffectsAo(position: THREE.Vector3) {
+    position.floor()
+    return this.affectsAo(this.chunkData.get(position))
+  }
+
+  private calculateVertexAO(position: THREE.Vector3) {
+    const { x, y, z } = position;
+    const neighborPosition = new THREE.Vector3(0, 0, 0);
+
+    let occlusion = 0;
+    const maxOcclusion = 8;
+
+    const checkNeighbor = (dx: number, dy: number, dz: number) => {
+      neighborPosition.set(x + dx, y + dy, z + dz);
+      return this.positionAffectsAo(neighborPosition);
+    };
+
+    // Check each of the three voxels touching the corner
+    if (checkNeighbor(0, 1, 0)) occlusion++;
+    if (checkNeighbor(1, 0, 0)) occlusion++;
+    if (checkNeighbor(0, 0, 1)) occlusion++;
+
+    // Check three voxels diagonal to the corner
+    if (checkNeighbor(1, 1, 0) && (checkNeighbor(0, 1, 0) || checkNeighbor(1, 0, 0))) occlusion++;
+    if (checkNeighbor(0, 1, 1) && (checkNeighbor(0, 1, 0) || checkNeighbor(0, 0, 1))) occlusion++;
+    if (checkNeighbor(1, 0, 1) && (checkNeighbor(1, 0, 0) || checkNeighbor(0, 0, 1))) occlusion++;
+    if (checkNeighbor(1, 1, 1) && (checkNeighbor(0, 1, 1) || checkNeighbor(1, 0, 1) || checkNeighbor(1, 1, 0))) occlusion++;
+
+    // Normalize the occlusion value
+    const aoValue = (maxOcclusion - occlusion) / maxOcclusion;
+    return aoValue;
   }
 }

--- a/src/game/world/ChunkMesher.ts
+++ b/src/game/world/ChunkMesher.ts
@@ -140,7 +140,7 @@ export class ChunkMesher {
 
     const color = blocks[blockId].color
 
-    const vertexPosition = new THREE.Vector3(0,0,0)
+    const vertexPosition = new THREE.Vector3(0, 0, 0)
 
     const faceVertices = ChunkMesher.vertexData
       .slice(firstFaceVertexIndex, firstFaceVertexIndex + FACE_VERTEX_COUNT)
@@ -155,7 +155,7 @@ export class ChunkMesher {
 
         // TODO: calculate light level
         // TODO: calculate UVs
-        return { ...vertex, position, color: color.map(v => v * ao) as [number,number,number] }
+        return { ...vertex, position, color: color.map(v => v * ao) as [number, number, number] }
       })
 
     return faceVertices
@@ -171,30 +171,30 @@ export class ChunkMesher {
   }
 
   private calculateVertexAO(position: THREE.Vector3) {
-    const { x, y, z } = position;
-    const neighborPosition = new THREE.Vector3(0, 0, 0);
+    const { x, y, z } = position
+    const neighborPosition = new THREE.Vector3(0, 0, 0)
 
-    let occlusion = 0;
-    const maxOcclusion = 8;
+    let occlusion = 0
+    const maxOcclusion = 8
 
     const checkNeighbor = (dx: number, dy: number, dz: number) => {
-      neighborPosition.set(x + dx, y + dy, z + dz);
-      return this.positionAffectsAo(neighborPosition);
-    };
+      neighborPosition.set(x + dx, y + dy, z + dz)
+      return this.positionAffectsAo(neighborPosition)
+    }
 
     // Check each of the three voxels touching the corner
-    if (checkNeighbor(0, 1, 0)) occlusion++;
-    if (checkNeighbor(1, 0, 0)) occlusion++;
-    if (checkNeighbor(0, 0, 1)) occlusion++;
+    if (checkNeighbor(0, 1, 0)) occlusion++
+    if (checkNeighbor(1, 0, 0)) occlusion++
+    if (checkNeighbor(0, 0, 1)) occlusion++
 
     // Check three voxels diagonal to the corner
-    if (checkNeighbor(1, 1, 0) && (checkNeighbor(0, 1, 0) || checkNeighbor(1, 0, 0))) occlusion++;
-    if (checkNeighbor(0, 1, 1) && (checkNeighbor(0, 1, 0) || checkNeighbor(0, 0, 1))) occlusion++;
-    if (checkNeighbor(1, 0, 1) && (checkNeighbor(1, 0, 0) || checkNeighbor(0, 0, 1))) occlusion++;
-    if (checkNeighbor(1, 1, 1) && (checkNeighbor(0, 1, 1) || checkNeighbor(1, 0, 1) || checkNeighbor(1, 1, 0))) occlusion++;
+    if (checkNeighbor(1, 1, 0) && (checkNeighbor(0, 1, 0) || checkNeighbor(1, 0, 0))) occlusion++
+    if (checkNeighbor(0, 1, 1) && (checkNeighbor(0, 1, 0) || checkNeighbor(0, 0, 1))) occlusion++
+    if (checkNeighbor(1, 0, 1) && (checkNeighbor(1, 0, 0) || checkNeighbor(0, 0, 1))) occlusion++
+    if (checkNeighbor(1, 1, 1) && (checkNeighbor(0, 1, 1) || checkNeighbor(1, 0, 1) || checkNeighbor(1, 1, 0))) occlusion++
 
     // Normalize the occlusion value
-    const aoValue = (maxOcclusion - occlusion) / maxOcclusion;
-    return aoValue;
+    const aoValue = (maxOcclusion - occlusion) / maxOcclusion
+    return aoValue
   }
 }


### PR DESCRIPTION
> In graphics, ambient occlusion is a shadowing technique used to make 3D objects look more realistic by simulating the soft shadows that should naturally occur when indirect or ambient lighting is cast out onto your scene.
> [Ambient Occlusion: What You Need to Know
](https://www.pluralsight.com/blog/film-games/understanding-ambient-occlusion)

This small change has a very prominent effect on the visual quality of any voxel game. By performing neighbor checking at every vertex and affecting the vertex color in this way, ambient shadows are calculated.

The effect is most noticable when using the [MeshBasicMaterial](https://threejs.org/docs/#api/en/materials/MeshBasicMaterial).

## Additional sources

https://0fps.net/2013/07/03/ambient-occlusion-for-minecraft-like-worlds/

## Screenshots

Before
![CleanShot 2024-02-12 at 16 13 27@2x](https://github.com/CuddlyBunion341/tsmc2/assets/53896675/bca4a0f5-5b2b-45b9-be39-ed7bfce681de)

After
![CleanShot 2024-02-12 at 16 13 01@2x](https://github.com/CuddlyBunion341/tsmc2/assets/53896675/95915a23-6c27-4af0-a343-a1733c0567e9)