### PR TITLE
(STALE) Implement vertex packing

### DIFF
--- a/src/game/main.ts
+++ b/src/game/main.ts
@@ -39,6 +39,8 @@ export default class Game implements Experience {
         callback: (args: MessageEvent<ArrayBuffer>) => {
           task.callback(args)
           chunk.updateMeshGeometry()
+          const helper = new THREE.BoxHelper(chunk.mesh)
+          this.engine.scene.add(helper)
         }
       })
     })

--- a/src/game/shaders/shader.frag
+++ b/src/game/shaders/shader.frag
@@ -1,10 +1,10 @@
 precision highp int;
 precision mediump float;
 
-in vec2 vUv;
+in float vAo;
 
 out vec4 outColor;
 
 void main() {
-  outColor = vec4(vUv.x, vUv.y, 0.0, 1.0);
+  outColor = vec4(vAo, vAo, vAo, 1.0);
 }

--- a/src/game/shaders/shader.frag
+++ b/src/game/shaders/shader.frag
@@ -2,9 +2,25 @@ precision highp int;
 precision mediump float;
 
 in float vAo;
+in vec3 bPos;
+flat in uint blockId;
 
 out vec4 outColor;
 
 void main() {
-  outColor = vec4(vAo, vAo, vAo, 1.0);
+  // float ao = vAo / 100.0;
+  // vec3 rgb = vec3(ao);
+  // vec3 posColor = vec3(bPos / 32.0);
+  // outColor = vec4(
+  //     mix(posColor.x, rgb.x, 0.5),
+  //     mix(posColor.y, rgb.y, 0.5),
+  //     mix(posColor.z, rgb.z, 0.5)
+  // , 1.0);
+  // outColor = vec4(posColor, 1.0);
+
+  if (blockId == 0u) outColor = vec4(1.0, 1.0, 1.0, 1.0);
+  else if (blockId == 1u) outColor = vec4(1.0, 0.0, 0.0, 1.0);
+  else if (blockId == 2u) outColor = vec4(0.0, 1.0, 0.0, 1.0);
+  else if (blockId == 3u) outColor = vec4(0.0, 0.0, 1.0, 1.0);
+  else outColor = vec4(1.0,1.0,0.0,1.0);
 }

--- a/src/game/shaders/shader.frag
+++ b/src/game/shaders/shader.frag
@@ -1,0 +1,10 @@
+precision highp int;
+precision mediump float;
+
+in vec2 vUv;
+
+out vec4 outColor;
+
+void main() {
+  outColor = vec4(vUv.x, vUv.y, 0.0, 1.0);
+}

--- a/src/game/shaders/shader.vert
+++ b/src/game/shaders/shader.vert
@@ -12,24 +12,30 @@ in uint data;
 
 out vec2 vUv;
 out vec3 vPos;
-out float ao;
+out float vAo;
 flat out uint blockId;
 
+const uint POS_X_MASK = 31u;
+const uint POS_Y_MASK = 992u;
+const uint POS_Z_MASK = 31744u;
+
+const uint POS_X_SIZE = 5u;
+const uint POS_Y_SIZE = 5u;
+const uint POS_Z_SIZE = 5u;
+
+const uint POS_X_SHIFT = 0u;
+const uint POS_Y_SHIFT = POS_X_SIZE;
+const uint POS_Z_SHIFT = (POS_X_SIZE + POS_Y_SIZE);
+
+const uint AO_MASK = 58720256u;
+const uint AO_SHIFT = (POS_X_SIZE + POS_Y_SIZE + POS_Z_SIZE);
+
 void main() {
-  // Data partition:
-  // posX: bit 0-4
-  // posY: bit 5-9
-  // posZ: bit 10-14
-  // blockId: bit 15-22
-  // ao: bit 23-25
-
-  float posX = float(data & 0x1F);
-  float posY = float((data >> 5) & 0x1F);
-  float posZ = float((data >> 10) & 0x1F);
+  float posX = float((data & POS_X_MASK) >> POS_X_SHIFT);
+  float posY = float((data & POS_Y_MASK) >> POS_Y_SHIFT);
+  float posZ = float((data & POS_Z_MASK) >> POS_Z_SHIFT);
   vPos = vec3(posX, posY, posZ);
-  blockId = data >> 15;
-  ao = float((data >> 23) & 0x7);
 
-  vUv = uv;
+  vAo = float((data & AO_MASK) >> AO_SHIFT) / 8.0;
   gl_Position = projectionMatrix * modelViewMatrix * vec4(vPos, 1.0);
 }

--- a/src/game/shaders/shader.vert
+++ b/src/game/shaders/shader.vert
@@ -12,6 +12,7 @@ in uint data;
 
 out vec2 vUv;
 out vec3 bPos;
+out vec3 vNormal;
 out float vAo;
 flat out uint blockId;
 
@@ -27,8 +28,32 @@ const uint POS_X_SHIFT = 0u;
 const uint POS_Y_SHIFT = POS_X_SIZE;
 const uint POS_Z_SHIFT = (POS_X_SIZE + POS_Y_SIZE);
 
+const uint AO_SIZE = 3u;
 const uint AO_MASK = 58720256u;
 const uint AO_SHIFT = (POS_X_SIZE + POS_Y_SIZE + POS_Z_SIZE);
+
+const uint VERTEX_INDEX_MASK = 16777215u;
+const uint VERTEX_INDEX_SHIFT = (POS_X_SIZE + POS_Y_SIZE + POS_Z_SIZE + AO_SIZE);
+
+struct Vertex {
+  vec3 position;
+  vec3 normal;
+  vec2 uv;
+};
+
+const Vertex[24] vertices = Vertex[24]( 
+    // left
+Vertex(vec3(-1, -1, -1), vec3(-1, 0, 0), vec2(0, 0)), Vertex(vec3(-1, -1, 1), vec3(-1, 0, 0), vec2(1, 0)), Vertex(vec3(-1, 1, -1), vec3(-1, 0, 0), vec2(0, 1)), Vertex(vec3(-1, 1, 1), vec3(-1, 0, 0), vec2(1, 1)),
+    // right
+Vertex(vec3(1, -1, 1), vec3(1, 0, 0), vec2(0, 0)), Vertex(vec3(1, -1, -1), vec3(1, 0, 0), vec2(1, 0)), Vertex(vec3(1, 1, 1), vec3(1, 0, 0), vec2(0, 1)), Vertex(vec3(1, 1, -1), vec3(1, 0, 0), vec2(1, 1)),
+    // bottom
+Vertex(vec3(1, -1, 1), vec3(0, -1, 0), vec2(0, 0)), Vertex(vec3(-1, -1, 1), vec3(0, -1, 0), vec2(1, 0)), Vertex(vec3(1, -1, -1), vec3(0, -1, 0), vec2(0, 1)), Vertex(vec3(-1, -1, -1), vec3(0, -1, 0), vec2(1, 1)),
+    // top
+Vertex(vec3(1, 1, -1), vec3(0, 1, 0), vec2(0, 0)), Vertex(vec3(-1, 1, -1), vec3(0, 1, 0), vec2(1, 0)), Vertex(vec3(1, 1, 1), vec3(0, 1, 0), vec2(0, 1)), Vertex(vec3(-1, 1, 1), vec3(0, 1, 0), vec2(1, 1)),
+    // back
+Vertex(vec3(1, -1, -1), vec3(0, 0, -1), vec2(0, 0)), Vertex(vec3(-1, -1, -1), vec3(0, 0, -1), vec2(1, 0)), Vertex(vec3(1, 1, -1), vec3(0, 0, -1), vec2(0, 1)), Vertex(vec3(-1, 1, -1), vec3(0, 0, -1), vec2(1, 1)),
+    // front
+Vertex(vec3(-1, -1, 1), vec3(0, 0, 1), vec2(0, 0)), Vertex(vec3(1, -1, 1), vec3(0, 0, 1), vec2(1, 0)), Vertex(vec3(-1, 1, 1), vec3(0, 0, 1), vec2(0, 1)), Vertex(vec3(1, 1, 1), vec3(0, 0, 1), vec2(1, 1)));
 
 void main() {
   float posX = float((data & POS_X_MASK) >> POS_X_SHIFT);

--- a/src/game/shaders/shader.vert
+++ b/src/game/shaders/shader.vert
@@ -11,7 +11,7 @@ uniform vec3 cameraPosition;
 in uint data;
 
 out vec2 vUv;
-out vec3 vPos;
+out vec3 bPos;
 out float vAo;
 flat out uint blockId;
 
@@ -34,8 +34,8 @@ void main() {
   float posX = float((data & POS_X_MASK) >> POS_X_SHIFT);
   float posY = float((data & POS_Y_MASK) >> POS_Y_SHIFT);
   float posZ = float((data & POS_Z_MASK) >> POS_Z_SHIFT);
-  vPos = vec3(posX, posY, posZ);
-
+  bPos = vec3(posX, posY, posZ);
   vAo = float((data & AO_MASK) >> AO_SHIFT) / 8.0;
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(vPos, 1.0);
+  blockId = data >> 24u;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(bPos, 1.0);
 }

--- a/src/game/shaders/shader.vert
+++ b/src/game/shaders/shader.vert
@@ -1,0 +1,35 @@
+precision highp int;
+precision mediump float;
+
+uniform mat4 modelMatrix;
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform mat4 viewMatrix;
+uniform mat3 normalMatrix;
+uniform vec3 cameraPosition;
+
+in uint data;
+
+out vec2 vUv;
+out vec3 vPos;
+out float ao;
+flat out uint blockId;
+
+void main() {
+  // Data partition:
+  // posX: bit 0-4
+  // posY: bit 5-9
+  // posZ: bit 10-14
+  // blockId: bit 15-22
+  // ao: bit 23-25
+
+  float posX = float(data & 0x1F);
+  float posY = float((data >> 5) & 0x1F);
+  float posZ = float((data >> 10) & 0x1F);
+  vPos = vec3(posX, posY, posZ);
+  blockId = data >> 15;
+  ao = float((data >> 23) & 0x7);
+
+  vUv = uv;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(vPos, 1.0);
+}

--- a/src/game/world/Chunk.ts
+++ b/src/game/world/Chunk.ts
@@ -2,6 +2,7 @@ import { ChunkData } from './ChunkData'
 import { ChunkMesher } from './ChunkMesher'
 import * as THREE from 'three'
 import { TerrainGenerator } from './TerrainGenerator'
+import { ChunkMaterial } from './ChunkMaterial'
 
 export type ChunkMessageData = {
   position: {
@@ -44,7 +45,7 @@ export class Chunk {
     this.chunkMesher = new ChunkMesher(dimensions, this.chunkData)
     this.mesh = new THREE.Mesh()
     this.mesh.position.add(this.position.clone().multiply(this.dimensions))
-    this.mesh.material = new THREE.MeshBasicMaterial({vertexColors: true})
+    this.mesh.material = ChunkMaterial.getMaterial()
   }
 
   generateTerrain() {

--- a/src/game/world/ChunkMaterial.ts
+++ b/src/game/world/ChunkMaterial.ts
@@ -3,26 +3,37 @@ import * as THREE from "three"
 export class ChunkMaterial {
   private static material: THREE.ShaderMaterial
 
-  private static uniforms = {time: {value: 0.0}}
+  private static uniforms = { time: { value: 0.0 } }
 
   private static createMaterial() {
-      return new THREE.ShaderMaterial({
-        uniforms: this.uniforms,
-        vertexShader: `
-          varying vec2 vUv;
-          void main() {
-            vUv = uv;
-            vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
-            gl_Position = projectionMatrix * modelViewPosition; 
-          }
+    return new THREE.RawShaderMaterial({
+      uniforms: this.uniforms,
+      vertexShader: /*glsl*/`
+        uniform mat4 modelMatrix;
+        uniform mat4 modelViewMatrix;
+        uniform mat4 projectionMatrix;
+        uniform mat4 viewMatrix;
+        uniform mat3 normalMatrix;
+        uniform vec3 cameraPosition;
+        attribute vec3 position;
+        attribute vec3 normal;
+        attribute vec2 uv;
+
+        varying vec2 vUv;
+        void main() {
+          vUv = uv;
+          vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
+          gl_Position = projectionMatrix * modelViewPosition; 
+        }
         `,
-        fragmentShader: `
+      fragmentShader: /*glsl*/`
+        precision highp float;
         varying vec2 vUv;
           void main() {
             gl_FragColor = vec4(vUv, 1.0, 1.0);
           }
         `
-      })
+    })
   }
 
   private static updateUniforms() {

--- a/src/game/world/ChunkMaterial.ts
+++ b/src/game/world/ChunkMaterial.ts
@@ -9,18 +9,17 @@ export class ChunkMaterial {
       return new THREE.ShaderMaterial({
         uniforms: this.uniforms,
         vertexShader: `
-          varying uint16 vData;
-
+          varying vec2 vUv;
           void main() {
-            vWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
-            vWorldNormal = normalize((modelMatrix * vec4(normal, 0.0)).xyz);
-            vViewPosition = cameraPosition;
-            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            vUv = uv;
+            vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
+            gl_Position = projectionMatrix * modelViewPosition; 
           }
         `,
         fragmentShader: `
+        varying vec2 vUv;
           void main() {
-            gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+            gl_FragColor = vec4(vUv, 1.0, 1.0);
           }
         `
       })

--- a/src/game/world/ChunkMaterial.ts
+++ b/src/game/world/ChunkMaterial.ts
@@ -12,7 +12,8 @@ export class ChunkMaterial {
       uniforms: this.uniforms,
       vertexShader,
       fragmentShader,
-      glslVersion: THREE.GLSL3
+      glslVersion: THREE.GLSL3,
+      side: THREE.DoubleSide, // TODO: remove once normals are implemented
     })
   }
 

--- a/src/game/world/ChunkMaterial.ts
+++ b/src/game/world/ChunkMaterial.ts
@@ -1,0 +1,41 @@
+import * as THREE from "three"
+
+export class ChunkMaterial {
+  private static material: THREE.ShaderMaterial
+
+  private static uniforms = {time: {value: 0.0}}
+
+  private static createMaterial() {
+      return new THREE.ShaderMaterial({
+        uniforms: this.uniforms,
+        vertexShader: `
+          varying uint16 vData;
+
+          void main() {
+            vWorldPosition = (modelMatrix * vec4(position, 1.0)).xyz;
+            vWorldNormal = normalize((modelMatrix * vec4(normal, 0.0)).xyz);
+            vViewPosition = cameraPosition;
+            gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+          }
+        `,
+        fragmentShader: `
+          void main() {
+            gl_FragColor = vec4(1.0, 1.0, 1.0, 1.0);
+          }
+        `
+      })
+  }
+
+  private static updateUniforms() {
+    this.uniforms.time.value = performance.now() / 1000
+    this.material.needsUpdate = true
+    requestAnimationFrame(() => this.updateUniforms())
+  }
+
+  public static getMaterial() {
+    if (!this.material) this.material = this.createMaterial()
+    this.updateUniforms()
+
+    return this.material
+  }
+}

--- a/src/game/world/ChunkMaterial.ts
+++ b/src/game/world/ChunkMaterial.ts
@@ -1,51 +1,23 @@
 import * as THREE from "three"
+import vertexShader from "../shaders/shader.vert"
+import fragmentShader from "../shaders/shader.frag"
 
 export class ChunkMaterial {
   private static material: THREE.ShaderMaterial
 
-  private static uniforms = { time: { value: 0.0 } }
+  private static uniforms = {}
 
   private static createMaterial() {
     return new THREE.RawShaderMaterial({
       uniforms: this.uniforms,
-      vertexShader: /*glsl*/`
-        uniform mat4 modelMatrix;
-        uniform mat4 modelViewMatrix;
-        uniform mat4 projectionMatrix;
-        uniform mat4 viewMatrix;
-        uniform mat3 normalMatrix;
-        uniform vec3 cameraPosition;
-        attribute vec3 position;
-        attribute vec3 normal;
-        attribute vec2 uv;
-
-        varying vec2 vUv;
-        void main() {
-          vUv = uv;
-          vec4 modelViewPosition = modelViewMatrix * vec4(position, 1.0);
-          gl_Position = projectionMatrix * modelViewPosition; 
-        }
-        `,
-      fragmentShader: /*glsl*/`
-        precision highp float;
-        varying vec2 vUv;
-          void main() {
-            gl_FragColor = vec4(vUv, 1.0, 1.0);
-          }
-        `
+      vertexShader,
+      fragmentShader,
+      glslVersion: THREE.GLSL3
     })
-  }
-
-  private static updateUniforms() {
-    this.uniforms.time.value = performance.now() / 1000
-    this.material.needsUpdate = true
-    requestAnimationFrame(() => this.updateUniforms())
   }
 
   public static getMaterial() {
     if (!this.material) this.material = this.createMaterial()
-    this.updateUniforms()
-
     return this.material
   }
 }

--- a/src/game/world/ChunkMesher.test.ts
+++ b/src/game/world/ChunkMesher.test.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import { describe, it, expect, beforeEach } from 'vitest'
-import { ChunkMesher, Vertex } from './ChunkMesher'
+import { ChunkMesher, Tripplet, Vertex } from './ChunkMesher'
 import { ChunkData } from './ChunkData'
 import { blockIds } from './blocks'
 
@@ -16,6 +16,64 @@ const assertVertexData = (vertex: Vertex) => {
   assertGeometryArray(vertex.normal, 3)
   assertGeometryArray(vertex.uv, 2)
 }
+
+const buildVertex = (): Vertex => {
+  return {
+    position: [0, 0, 0],
+    normal: [0, 0, 0],
+    uv: [0, 0],
+    color: [0, 0, 0],
+    blockId: 0,
+    ao: 0
+  }
+}
+
+
+describe('.encodeVertex()', () => {
+
+  it('encodes empty vertex correctly', () => {
+    const vertex = buildVertex()
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b000_00000000_00000_00000_000000)
+  })
+
+  it('encodes position data correctly', () => {
+    const vertex = {...buildVertex(), position: [1,2,3] as Tripplet<number>}
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b000_00000000_00011_00010_00001)
+  })
+
+
+  it('encodes position data correctly at chunk borders', () => {
+    const vertex = {...buildVertex(), position: [31,31,31] as Tripplet<number>}
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b000_00000000_11111_11111_11111)
+  })
+
+  it('encodes block data correctly', () => {
+    const vertex = {...buildVertex(), blockId: 179}
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b000_10110011_00000_00000_00000)
+  })
+
+  it('encodes ambient occlusion data correctly', () => {
+    const vertex = {...buildVertex(), ao: 0.625}
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b101_00000000_00000_00000_00000)
+  })
+
+  it('encodes all data correctly', () => {
+    const vertex = {
+      ...buildVertex(),
+      position: [1,2,3] as Tripplet<number>,
+      blockId: 4,
+      ao: 0.625
+    }
+
+    const encoded = ChunkMesher.encodeVertex(vertex)
+    expect(encoded).toEqual(0b101_00000100_00011_00010_00001)
+  })
+})
 
 describe('#generateFaceGeometry()', () => {
   it('should generate the correct face', () => {

--- a/src/game/world/ChunkMesher.ts
+++ b/src/game/world/ChunkMesher.ts
@@ -2,55 +2,53 @@ import * as THREE from 'three'
 import { blockIds, blocks } from './blocks'
 import { ChunkData } from './ChunkData'
 
+export type Tripplet<T> = [T, T, T]
+export type Touple<T> = [T, T]
+
 export type Vertex = {
-  position: [number, number, number]
-  normal: [number, number, number]
-  uv: [number, number]
-  color: [number, number, number]
+  blockId: number
+  ao: number
+  position: Tripplet<number>
+  normal: Tripplet<number>
+  uv: Touple<number>
+  color: Tripplet<number>
 }
 
 const FACE_COUNT = 6
 const FACE_VERTEX_COUNT = 4
 
 export class ChunkMesher {
-  static geometryAttributes = [
-    { name: 'position', size: 3 },
-    { name: 'normal', size: 3 },
-    { name: 'uv', size: 2 },
-    { name: 'color', size: 3 }
-  ] as const
-
   static vertexData: Vertex[] = [
     // left
-    { color: [0, 0, 0], position: [-1, -1, -1], normal: [-1, 0, 0], uv: [0, 0] },
-    { color: [0, 0, 0], position: [-1, -1, 1], normal: [-1, 0, 0], uv: [1, 0] },
-    { color: [0, 0, 0], position: [-1, 1, -1], normal: [-1, 0, 0], uv: [0, 1] },
-    { color: [0, 0, 0], position: [-1, 1, 1], normal: [-1, 0, 0], uv: [1, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, -1], normal: [-1, 0, 0], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, 1], normal: [-1, 0, 0], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, -1], normal: [-1, 0, 0], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, 1], normal: [-1, 0, 0], uv: [1, 1] },
     // right
-    { color: [0, 0, 0], position: [1, -1, 1], normal: [1, 0, 0], uv: [0, 0] },
-    { color: [0, 0, 0], position: [1, -1, -1], normal: [1, 0, 0], uv: [1, 0] },
-    { color: [0, 0, 0], position: [1, 1, 1], normal: [1, 0, 0], uv: [0, 1] },
-    { color: [0, 0, 0], position: [1, 1, -1], normal: [1, 0, 0], uv: [1, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, 1], normal: [1, 0, 0], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, -1], normal: [1, 0, 0], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, 1], normal: [1, 0, 0], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, -1], normal: [1, 0, 0], uv: [1, 1] },
     // bottom
-    { color: [0, 0, 0], position: [1, -1, 1], normal: [0, -1, 0], uv: [0, 0] },
-    { color: [0, 0, 0], position: [-1, -1, 1], normal: [0, -1, 0], uv: [1, 0] },
-    { color: [0, 0, 0], position: [1, -1, -1], normal: [0, -1, 0], uv: [0, 1] },
-    { color: [0, 0, 0], position: [-1, -1, -1], normal: [0, -1, 0], uv: [1, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, 1], normal: [0, -1, 0], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, 1], normal: [0, -1, 0], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, -1], normal: [0, -1, 0], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, -1], normal: [0, -1, 0], uv: [1, 1] },
     // top
-    { color: [0, 0, 0], position: [1, 1, -1], normal: [0, 1, 0], uv: [0, 0] },
-    { color: [0, 0, 0], position: [-1, 1, -1], normal: [0, 1, 0], uv: [1, 0] },
-    { color: [0, 0, 0], position: [1, 1, 1], normal: [0, 1, 0], uv: [0, 1] },
-    { color: [0, 0, 0], position: [-1, 1, 1], normal: [0, 1, 0], uv: [1, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, -1], normal: [0, 1, 0], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, -1], normal: [0, 1, 0], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, 1], normal: [0, 1, 0], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, 1], normal: [0, 1, 0], uv: [1, 1] },
     // back
-    { color: [0, 0, 0], position: [1, -1, -1], normal: [0, 0, -1], uv: [0, 0] },
-    { color: [0, 0, 0], position: [-1, -1, -1], normal: [0, 0, -1], uv: [1, 0] },
-    { color: [0, 0, 0], position: [1, 1, -1], normal: [0, 0, -1], uv: [0, 1] },
-    { color: [0, 0, 0], position: [-1, 1, -1], normal: [0, 0, -1], uv: [1, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, -1], normal: [0, 0, -1], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, -1], normal: [0, 0, -1], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, -1], normal: [0, 0, -1], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, -1], normal: [0, 0, -1], uv: [1, 1] },
     // front
-    { color: [0, 0, 0], position: [-1, -1, 1], normal: [0, 0, 1], uv: [0, 0] },
-    { color: [0, 0, 0], position: [1, -1, 1], normal: [0, 0, 1], uv: [1, 0] },
-    { color: [0, 0, 0], position: [-1, 1, 1], normal: [0, 0, 1], uv: [0, 1] },
-    { color: [0, 0, 0], position: [1, 1, 1], normal: [0, 0, 1], uv: [1, 1] }
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, -1, 1], normal: [0, 0, 1], uv: [0, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, -1, 1], normal: [0, 0, 1], uv: [1, 0] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [-1, 1, 1], normal: [0, 0, 1], uv: [0, 1] },
+    { ao: 0, blockId: 0, color: [0, 0, 0], position: [1, 1, 1], normal: [0, 0, 1], uv: [1, 1] }
   ] as const
 
   static vertexIndices = [0, 1, 2, 2, 1, 3] as const
@@ -68,21 +66,43 @@ export class ChunkMesher {
     return mesh
   }
 
+  static encodeVertex(vertex: Vertex) {
+    // encodes vertex data into a single 32 bit integer
+    // 0b000000_AAA_BBBBBBBB_ZZZZZ_YYYYY_XXXXX
+
+    let vertexData =  0
+
+    vertexData |= vertex.position[0] & 0b11111
+    vertexData |= (vertex.position[1] & 0b11111) << 5
+    vertexData |= (vertex.position[2] & 0b11111) << 10
+
+    vertexData |= vertex.blockId << 15
+    vertexData |= ((vertex.ao * 8) & 0b111) << 23
+
+    return vertexData
+  }
+
+  packVertexData() {
+    const {vertices, indices} = this.generateChunkVertices()
+    const vertexData = vertices.map(ChunkMesher.encodeVertex) 
+
+    return { vertices: vertexData, indices }
+  }
+
   generateGeometry() {
-    const { vertices, indices } = this.generateChunkVertices()
+    const { vertices, indices } = this.packVertexData()
 
     const geometry = new THREE.BufferGeometry()
 
-    ChunkMesher.geometryAttributes.forEach(({ name, size }) => {
-      const attributeData = vertices.map((v) => v[name]).flat()
-      const attribute = new THREE.BufferAttribute(new Float32Array(attributeData), size)
-      geometry.setAttribute(name, attribute)
-    })
+    const attribute = new THREE.Uint32BufferAttribute(new Uint32Array(vertices), 1)
+    attribute.gpuType = THREE.IntType
+    geometry.setAttribute('data', attribute)
 
     geometry.setIndex(indices)
 
     return geometry
   }
+  
 
   private static isSolid(block: number) {
     if (block === 0) return false
@@ -138,7 +158,7 @@ export class ChunkMesher {
   generateFaceVertices(faceIndex: number, blockId: number, blockPosition: THREE.Vector3) {
     const firstFaceVertexIndex = faceIndex * FACE_VERTEX_COUNT
 
-    const color = blocks[blockId].color
+    // const color = blocks[blockId].color
 
     const vertexPosition = new THREE.Vector3(0, 0, 0)
 
@@ -155,7 +175,8 @@ export class ChunkMesher {
 
         // TODO: calculate light level
         // TODO: calculate UVs
-        return { ...vertex, position, color: color.map(v => v * ao) as [number, number, number] }
+        // return { ...vertex, position, blockId, color: color.map(v => v * ao) as [number, number, number] }
+        return {...vertex, position, blockId, ao }
       })
 
     return faceVertices

--- a/src/game/world/ChunkMesher.ts
+++ b/src/game/world/ChunkMesher.ts
@@ -133,8 +133,6 @@ export class ChunkMesher {
     const {vertices, indices} = this.generateChunkVertices()
     const vertexData = vertices.map(ChunkMesher.encodeVertex) 
 
-    console.log(PACKING_CONSTANTS)
-
     return { vertices: vertexData, indices }
   }
 

--- a/src/game/world/VertexPacker.test.ts
+++ b/src/game/world/VertexPacker.test.ts
@@ -1,0 +1,5 @@
+import { describe, expect, test } from "vitest";
+
+describe('#encodeVertex()', () => {
+
+})

--- a/src/game/world/VertexPacker.ts
+++ b/src/game/world/VertexPacker.ts
@@ -1,6 +1,6 @@
 import { Vertex } from "./ChunkMesher"
 
-export type VertexPropertyName = 'positionX' | 'positionY' | 'positionZ' | 'blockId' | 'ao'
+export type VertexPropertyName = 'positionX' | 'positionY' | 'positionZ' | 'blockId' | 'ao' | 'vertexIndex'
 export type VertexPackage = {
   name: VertexPropertyName
   bits: number
@@ -12,6 +12,7 @@ export type VertexPackage = {
 export type VertexPackageInput = Pick<VertexPackage, "name" | "bits">
 
 export const defaultVertexPackages: VertexPackageInput[] = [
+  { name: 'vertexIndex', bits: 5 },
   { name: 'positionX', bits: 5 },
   { name: 'positionY', bits: 5 },
   { name: 'positionZ', bits: 5 },

--- a/src/game/world/VertexPacker.ts
+++ b/src/game/world/VertexPacker.ts
@@ -1,3 +1,5 @@
+import { Vertex } from "./ChunkMesher"
+
 export type VertexPropertyName = 'positionX' | 'positionY' | 'positionZ' | 'blockId' | 'ao'
 export type VertexPackage = {
   name: VertexPropertyName
@@ -19,6 +21,7 @@ export const defaultVertexPackages: VertexPackageInput[] = [
 
 export class VertexPacker {
   public packages: VertexPackage[]
+  public hash!: Record<VertexPropertyName, VertexPackage>
   public validator: VertexPackerValidator
   public calculator: VertexPackerCalculator
 
@@ -41,10 +44,23 @@ export class VertexPacker {
   public calculateAll() {
     this.calculator.calculateAll()
     this.validator.validateCalculation()
+    this.hash = this.calculator.calculatePackingHash()
   }
 
   public toUniforms() {
     // TODO: Implement
+  }
+
+  public packVertex(vertex: Vertex) {
+    let vertexData = 0
+
+    vertexData |= vertex.position[0] & this.hash.positionX.encodingMask << this.hash.positionX.offset
+    vertexData |= vertex.position[1] & this.hash.positionY.encodingMask << this.hash.positionY.offset
+    vertexData |= vertex.position[2] & this.hash.positionZ.encodingMask << this.hash.positionZ.offset
+    vertexData |= vertex.blockId & this.hash.blockId.encodingMask << this.hash.blockId.offset
+    vertexData |= vertex.ao & this.hash.ao.encodingMask << this.hash.ao.offset
+
+    return vertexData
   }
 }
 

--- a/src/game/world/VertexPacker.ts
+++ b/src/game/world/VertexPacker.ts
@@ -1,0 +1,121 @@
+export type VertexPropertyName = 'positionX' | 'positionY' | 'positionZ' | 'blockId' | 'ao'
+export type VertexPackage = {
+  name: VertexPropertyName
+  bits: number
+  offset: number
+  encodingMask: number
+  decodingMask: number
+}
+
+export type VertexPackageInput = Pick<VertexPackage, "name" | "bits">
+
+export const defaultVertexPackages: VertexPackageInput[] = [
+  { name: 'positionX', bits: 5 },
+  { name: 'positionY', bits: 5 },
+  { name: 'positionZ', bits: 5 },
+  { name: 'blockId', bits: 8 },
+  { name: 'ao', bits: 3 },
+]
+
+export class VertexPacker {
+  public packages: VertexPackage[]
+
+  constructor(VertexPackages: VertexPackageInput[] = defaultVertexPackages) {
+    this.packages = VertexPackages.map((input) => {
+      return {
+        ...input,
+        offset: 0,
+        encodingMask: 0,
+        decodingMask: 0
+      }
+    })
+
+    this.validateInput()
+  }
+
+  public toUniforms() {
+    // TODO: Implement
+  }
+
+  public validateTotalBits() {
+    const totalBits = this.packages.reduce((total, property) => {
+      return total + property.bits
+    }, 0)
+    if (totalBits > 32) {
+      throw new Error('Total bits exceeds 32')
+    }
+  }
+
+  public validateNoOverlaps() {
+    const offsets = this.packages.map((property) => property.offset)
+    const uniqueOffsets = new Set(offsets)
+    if (offsets.length !== uniqueOffsets.size) {
+      throw new Error('Overlapping offsets')
+    }
+  }
+
+  public validateNoGaps() {
+    const sortedOffsets = this.packages.map((property) => property.offset).sort((a, b) => a - b)
+    for (let i = 0; i < sortedOffsets.length - 1; i++) {
+      if (sortedOffsets[i + 1] - sortedOffsets[i] !== this.packages[i].bits) {
+        throw new Error('Gaps in offsets')
+      }
+    }
+  }
+
+  public validateAllPresent() {
+    const properties = new Set(this.packages.map((property) => property.name))
+    const requiredProperties = new Set<VertexPropertyName>(['positionX', 'positionY', 'positionZ', 'blockId', 'ao'])
+    for (const property of requiredProperties) {
+      if (!properties.has(property)) {
+        throw new Error(`Missing property: ${property}`)
+      }
+    }
+  }
+
+  public validatePropertyDuplication() {
+    const properties = new Set(this.packages.map((property) => property.name))
+    if (properties.size !== this.packages.length) {
+      throw new Error('Duplicate properties')
+    }
+  }
+
+  public validateInput() {
+    this.validateAllPresent()
+    this.validatePropertyDuplication()
+    this.validateTotalBits()
+  }
+
+  public validateCalculation() {
+    this.validateNoOverlaps()
+    this.validateNoGaps()
+  }
+
+  public calculateOffsets() {
+    this.packages.reduce((offset, property) => {
+      property.offset = offset
+      return offset + property.bits
+    }, 0)
+  }
+
+  public calculateMasks() {
+    this.packages.forEach((property) => {
+      property.encodingMask = (1 << property.bits) - 1
+      property.decodingMask = property.encodingMask << property.offset
+    })
+  }
+
+  public calculatePackingHash() {
+    const hash: Record<VertexPropertyName, VertexPackage> = {} as Record<VertexPropertyName, VertexPackage>
+    this.packages.forEach((property) => {
+      hash[property.name] = property
+    })
+    return hash
+  }
+
+  public calculateAll() {
+    this.calculateOffsets()
+    this.calculateMasks()
+    return this.calculatePackingHash()
+  }
+}


### PR DESCRIPTION
This PR aims at reducing memory usage by combining buffers for position, normals, block information and ambient occlusion into one single Uint32 Buffer.

Main idea for this optimization: [Voxel Game Mesh Optimizations](https://www.youtube.com/watch?v=VQuN1RMEr1c&t=9s)

## Easel

![CleanShot 2024-02-13 at 21 07 51@2x](https://github.com/CuddlyBunion341/tsmc2/assets/53896675/dfe27f04-1286-4fb9-bf69-016db0513ccb)

## Sources
* [Constant from GLSL shader](https://stackoverflow.com/questions/26541144/getting-a-constant-from-a-glsl-shader)
* [Custom vertex attributes](https://discourse.threejs.org/t/uint32-custom-vertex-attribute-rejected-as-invalid/14019)
* [Glsl 3 syntax](https://hub.packtpub.com/getting-started-opengl-es-30-using-glsl-30/)
* [Integer buffers three.js example](https://threejs.org/examples/?q=integer#webgl2_buffergeometry_attributes_integer)
* [Glsl Data types](https://learnwebgl.brown37.net/12_shader_language/glsl_data_types.html)
* [Webgl specification](https://registry.khronos.org/webgl/specs/1.0/#5.14.10)
* [Webgl attributes](https://webglfundamentals.org/webgl/lessons/webgl-attributes.html)
* [Three.js raw shader example](https://threejs.org/examples/webgl_buffergeometry_rawshader.html)
* [Shader tutorial threejs](https://dev.to/maniflames/creating-a-custom-shader-in-threejs-3bhi)